### PR TITLE
Update helpers.php

### DIFF
--- a/api/helpers.php
+++ b/api/helpers.php
@@ -2,7 +2,7 @@
 
 // Patch for when using nginx instead of apache, source: http://php.net/manual/en/function.getallheaders.php#84262
 if (!function_exists('getallheaders')) { 
-    function getallheaders() \{ 
+    function getallheaders() { 
         $headers = ''; 
         
         foreach ($_SERVER as $name => $value) { 


### PR DESCRIPTION
A patch for when people are using nginx (or any other webserver) instead of apache to serve Taskboard. This adds an helper function from php.net and replaces the apache_ functions with the generic getallheaders, that is supported since php 5.3.
