### PR TITLE
Fixes typos in board partial

### DIFF
--- a/partials/board.html
+++ b/partials/board.html
@@ -84,7 +84,7 @@
                 </div>
             </div>
             <div id="itemMenu" class="dropdown" style="position: fixed;">
-                <ul class="dropdown-menu" role"menu">
+                <ul class="dropdown-menu" role="menu">
                     <li role="presentation">
                         <a role="menuitem" style="cursor: default" data-ng-click="openItem(contextItem)">
                             View Item
@@ -109,7 +109,7 @@
                 </ul>
             </div>
             <div id="laneMenu" class="dropdown" style="position: fixed;">
-                <ul class="dropdown-menu" role"menu">
+                <ul class="dropdown-menu" role="menu">
                     <li role="presentation">
                         <a role="menuitem" style="cursor: default" data-ng-click="openAddItem()">
                             Add New Item


### PR DESCRIPTION
Two roles where not defined because of forgotten equals signs, this is probably a typo, but fixed with this commit.
