### PR TITLE
Google web fonts fix

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -12,6 +12,8 @@
     #3rdParty - Styles for 3rd party widgets (noty, calendar, etc.)
 */
 
+@import url(http://fonts.googleapis.com/css?family=Pontano+Sans|Raleway:500);
+
 /* #General */
 html, body {
     height: 100%;width: 100%;

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
         <link rel="stylesheet" href="lib/css/jquery-ui.min.css">
         <link rel="stylesheet" href="lib/css/jquery-ui.structure.min.css">
         <link rel="stylesheet" href="lib/css/spectrum.css">
-        <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Pontano+Sans|Raleway:500">
         <link rel="stylesheet" href="css/styles.css">
 
         <!--[if lt IE 9]>

--- a/indexProd.html
+++ b/indexProd.html
@@ -10,7 +10,6 @@
         <title>TaskBoard</title>
 
         <link rel="stylesheet" href="lib/css/combined.min.css">
-        <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Pontano+Sans%7CRaleway:500">
         <link rel="stylesheet" href="css/styles.min.css">
 
         <!--[if lt IE 9]>


### PR DESCRIPTION
Currently Google Webfonts are not working. This adds a static import in the general CSS, which should be more clean and removes the web fonts reference from the html.
