### PR TITLE
Leave space between inputs and buttons

### DIFF
--- a/partials/settingsBoardModal.html
+++ b/partials/settingsBoardModal.html
@@ -33,7 +33,7 @@
                                 </span>
                             </li>
                         </ul>
-                        <input class="form-control" style="width: 85%;" type="text" placeholder="Column Name"
+                        <input class="form-control" style="width: 85%; margin-bottom: 5px;" type="text" placeholder="Column Name"
                                data-ng-model="boardFormData.laneName" data-ng-disabled="boardFormData.isSaving">
                         <button type="submit" id="modalAddLane" class="btn btn-default fa fa-plus"
                                 data-ng-disabled="boardFormData.isSaving"></button>
@@ -54,7 +54,7 @@
                                 </span>
                             </li>
                         </ul>
-                        <input class="form-control" style="width: 85%;" type="text" placeholder="Category Name"
+                        <input class="form-control" style="width: 85%; margin-bottom: 5px;" type="text" placeholder="Category Name"
                                data-ng-model="boardFormData.categoryName" data-ng-disabled="boardFormData.isSaving">
                         <button type="submit" id="modalAddCategory" class="btn btn-default fa fa-plus"
                                 data-ng-disabled="boardFormData.isSaving"></button>


### PR DESCRIPTION
The inputs and buttons for adding Categories and Columns in the Add Board modal were smashed together. This just adds a margin at the bottom of the input to add some space to make it a little more aesthetically pleasing.