### PR TITLE
Updated compatibility of arrays with PHP 5.x.

### DIFF
--- a/api/boardRoutes.php
+++ b/api/boardRoutes.php
@@ -78,7 +78,7 @@ $app->post('/boards/remove', function() use($app, $jsonResponse) {
             R::trashAll($board->xownCategory);
             R::trashAll($board->xownAutoaction);
             R::trash($board);
-            R::exec('DELETE from board_user WHERE board_id = ?', [$data->boardId]);
+            R::exec('DELETE from board_user WHERE board_id = ?', array($data->boardId));
             $jsonResponse->addAlert('success', 'Removed board ' . $board->name . '.');
             $actor = getUser();
             logAction($actor->username . ' removed board ' . $board->name, $before, null);
@@ -139,7 +139,7 @@ $app->post('/lanes/:laneId/toggle', function($laneId) use($app, $jsonResponse) {
     if (validateToken()) {
         $user = getUser();
         $lane = R::load('lane', $laneId);
-        $collapsed = R::findOne('collapsed', ' user_id = ? AND lane_id = ? ', [$user->id, $laneId]);
+        $collapsed = R::findOne('collapsed', ' user_id = ? AND lane_id = ? ', array($user->id, $laneId));
 
         if (null != $collapsed) {
             R::trash($collapsed);
@@ -155,7 +155,7 @@ $app->post('/lanes/:laneId/toggle', function($laneId) use($app, $jsonResponse) {
         $jsonResponse->addBeans(getBoards());
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['laneId' => '\d+']); // Numbers only.
+})->conditions(array('laneId' => '\d+')); // Numbers only.
 
 $app->post('/boards/:boardId/toggleActive', function($boardId) use($app, $jsonResponse) {
     if (validateToken()) {
@@ -175,4 +175,4 @@ $app->post('/boards/:boardId/toggleActive', function($boardId) use($app, $jsonRe
         }
      }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['boardId' => '\d+']); // Numbers only.
+})->conditions(array('boardId' => '\d+')); // Numbers only.

--- a/api/helpers.php
+++ b/api/helpers.php
@@ -40,7 +40,7 @@ function setUserToken($user, $expires) {
     $dbToken->token = $token;
 
     if (null == $user->ownToken) {
-        $user->ownToken = [];
+        $user->ownToken = array();
     }
     $user->ownToken[] = $dbToken;
 
@@ -50,9 +50,9 @@ function setUserToken($user, $expires) {
 // Get the user making the current request.
 function getUser() {
     global $jsonResponse;
-
-    if (isset(getallheaders()['Authorization'])) {
-        $hash = getallheaders()['Authorization'];
+    $gah = getallheaders();
+    if (isset($gah['Authorization'])) {
+        $hash = $gah['Authorization'];
         try {
             $payload = JWT::decode($hash, getJwtKey());
             $user = R::load('user', $payload->uid);
@@ -94,7 +94,8 @@ function getLaneByID($id) {
 // Get all users.
 function getUsers($sanitize = true) {
     try {
-        $hash = getallheaders()['Authorization'];
+        $gah = getallheaders();
+        $hash = $gah['Authorization'];
         $payload = JWT::decode($hash, getJwtKey());
 
         $users = R::findAll('user');
@@ -153,7 +154,7 @@ function getBoards() {
     if ($user->isAdmin) {
         return $boards;
     } else {
-        $filteredBoards = [];
+        $filteredBoards = array();
         foreach($boards as $board) {
             foreach($board->sharedUser as $boardUser) {
                 if ($user->username == $boardUser->username) {
@@ -167,7 +168,7 @@ function getBoards() {
 
 // Finds the removed IDs for updating a board.
 function getIdsToRemove($boardList, $dataList) {
-    $retVal = [];
+    $retVal = array();
     foreach($boardList as $item) {
         $remove = true;
         foreach($dataList as $newItem) {
@@ -199,7 +200,7 @@ function loadBoardData($board, $data) {
         $lane->position = intval($item->position);
 
         if (null == $lane->ownItems) {
-            $lane->ownItems = [];
+            $lane->ownItems = array();
         }
         // New lane, add it to the board
         if (!$lane->id) {
@@ -246,14 +247,14 @@ function loadBoardData($board, $data) {
 // Clean a user bean for return to front-end.
 function sanitize($user) {
     $user['salt'] = null;
-    $user->ownToken = [];
+    $user->ownToken = array();
     $user['password'] = null;
 }
 
 // Change username if available.
 function updateUsername($user, $data) {
     global $jsonResponse;
-    $nameTaken = R::findOne('user', ' username = ?', [$data->newUsername]);
+    $nameTaken = R::findOne('user', ' username = ?', array($data->newUsername));
 
     if (null != $user && null == $nameTaken) {
         $user->username = $data->newUsername;
@@ -268,7 +269,7 @@ function updateUsername($user, $data) {
 // Change email if available.
 function updateEmail($user, $data) {
     global $jsonResponse;
-    $emailTaken = R::findOne('user', ' username = ?', [$data->newEmail]);
+    $emailTaken = R::findOne('user', ' username = ?', array($data->newEmail));
 
     if (null != $user && null == $emailTaken) {
         $user->email = $data->newEmail;
@@ -311,8 +312,9 @@ function checkDbToken() {
     $isValid = false;
 
     if (null != $user) {
-        if (isset(getallheaders()['Authorization'])) {
-            $hash = getallheaders()['Authorization'];
+        $gah = getallheaders();
+        if (isset($gah['Authorization'])) {
+            $hash = $gah['Authorization'];
 
             foreach ($user->ownToken as $token) {
                 if ($hash == $token->token) {
@@ -328,15 +330,16 @@ function checkDbToken() {
 // Clear a user's token from the DB.
 function clearDbToken() {
     $payload = null;
-
+    $gah = getallheaders();
     try {
-        $payload = JWT::decode(getallheaders()['Authorization'], getJwtKey());
+
+        $payload = JWT::decode($gah['Authorization'], getJwtKey());
     } catch (Exception $e) {}
 
     if (null != $payload) {
         $user = R::load('user', $payload->uid);
         if (0 != $user->id) {
-            $hash = getallheaders()['Authorization'];
+            $hash = $gah['Authorization'];
 
             foreach ($user->ownToken as $token) {
                 if ($hash == $token->token) {

--- a/api/itemRoutes.php
+++ b/api/itemRoutes.php
@@ -59,7 +59,7 @@ $app->post('/boards/:id/items', function($id) use($app, $jsonResponse) {
         }
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['id' => '\d+']); // Numbers only.
+})->conditions(array('id' => '\d+')); // Numbers only.
 
 //Update existing item
 $app->post('/items/:itemId', function($itemId) use ($app, $jsonResponse) {
@@ -121,7 +121,7 @@ $app->post('/items/:itemId', function($itemId) use ($app, $jsonResponse) {
         }
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['itemId' => '\d+']);
+})->conditions(array('itemId' => '\d+'));
 
 // Update item positions
 $app->post('/items/positions', function() use ($app, $jsonResponse) {
@@ -200,7 +200,7 @@ $app->post('/items/:itemId/comment', function($itemId) use ($app, $jsonResponse)
         }
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['itemId' => '\d+']);
+})->conditions(array('itemId' => '\d+'));
 
 // Update an existing comment
 $app->post('/comments/:commentId', function($commentId) use ($app, $jsonResponse) {
@@ -241,7 +241,7 @@ $app->post('/comments/:commentId', function($commentId) use ($app, $jsonResponse
         }
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['commentId' => '\d+']);
+})->conditions(array('commentId' => '\d+'));
 
 // Remove a comment from an item.
 $app->post('/items/:itemId/comment/remove', function($itemId) use ($app, $jsonResponse) {
@@ -261,7 +261,7 @@ $app->post('/items/:itemId/comment/remove', function($itemId) use ($app, $jsonRe
         }
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['itemId' => '\d+']);
+})->conditions(array('itemId' => '\d+'));
 
 // Add an attachment to an item.
 $app->post('/items/:itemId/upload', function($itemId) use ($app, $jsonResponse) {
@@ -293,7 +293,7 @@ $app->post('/items/:itemId/upload', function($itemId) use ($app, $jsonResponse) 
         $jsonResponse->addBeans($item);
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['itemId' => '\d+']);
+})->conditions(array('itemId' => '\d+'));
 
 // Get an item attachment's information.
 $app->get('/items/:itemId/upload/:attachmentId', function($itemId, $attachmentId) use ($app, $jsonResponse) {
@@ -310,7 +310,7 @@ $app->get('/items/:itemId/upload/:attachmentId', function($itemId, $attachmentId
         }
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['itemId' => '\d+', 'attachmentId' => '\d+']);
+})->conditions(array('itemId' => '\d+', 'attachmentId' => '\d+'));
 
 // Remove an attachment from an item.
 $app->post('/items/:itemId/upload/remove', function($itemId) use ($app, $jsonResponse) {
@@ -336,7 +336,7 @@ $app->post('/items/:itemId/upload/remove', function($itemId) use ($app, $jsonRes
         }
     }
     $app->response->setBody($jsonResponse->asJson());
-})->conditions(['itemId' => '\d+']);
+})->conditions(array('itemId' => '\d+'));
 
 // Remove an item.
 $app->post('/items/remove', function() use ($app, $jsonResponse) {

--- a/api/jsonResponse.php
+++ b/api/jsonResponse.php
@@ -17,6 +17,6 @@ class JsonResponse {
     }
 
     function addAlert($type, $text) {
-        $this->alerts[] = ['type' => $type, 'text' => $text];
+        $this->alerts[] = array('type' => $type, 'text' => $text);
     }
 }

--- a/api/userRoutes.php
+++ b/api/userRoutes.php
@@ -8,7 +8,7 @@ $app->post('/login', function() use ($app, $jsonResponse) {
         ? (2 * 7 * 24 * 60 * 60) /* Two weeks */
         : (1.5 * 60 * 60) /* One and a half hours */;
 
-    $lookup = R::findOne('user', ' username = ? ', [$data->username]);
+    $lookup = R::findOne('user', ' username = ? ', array($data->username));
 
     $jsonResponse->message = 'Invalid username or password.';
     $app->response->setStatus(401);
@@ -27,7 +27,7 @@ $app->post('/login', function() use ($app, $jsonResponse) {
 
             logAction($lookup->username . ' logged in.', null, null);
             $jsonResponse->message = 'Login successful.';
-            $jsonResponse->data = R::findOne('token', ' user_id = ? ORDER BY id DESC ', [$lookup->id])->token;
+            $jsonResponse->data = R::findOne('token', ' user_id = ? ORDER BY id DESC ', array($lookup->id))->token;
             $app->response->setStatus(200);
         }
     }
@@ -139,19 +139,19 @@ $app->get('/users/current', function() use($app, $jsonResponse) {
         $user = getUser();
         if (null != $user) {
             $userOptions = R::exportAll($user->ownOption);
-            $options = [
+            $options = array(
                 'tasksOrder' => $userOptions[0]['tasks_order'],
                 'showAssignee' => $userOptions[0]['show_assignee'] == 1,
                 'showAnimations' => $userOptions[0]['show_animations'] == 1
-            ];
-            $jsonResponse->data = [
+            );
+            $jsonResponse->data = array(
                 'userId' => $user->id,
                 'username' => $user->username,
                 'isAdmin' => $user->isAdmin,
                 'email' => $user->email,
                 'defaultBoard' => $user->defaultBoard,
                 'options' => $options
-            ];
+            );
         }
     }
     $app->response->setBody($jsonResponse->asJson());
@@ -186,7 +186,7 @@ $app->post('/users', function() use($app, $jsonResponse) {
     $data = json_decode($app->environment['slim.input']);
 
     if (validateToken(true)) {
-        $nameTaken = R::findOne('user', ' username = ?', [$data->username]);
+        $nameTaken = R::findOne('user', ' username = ?', array($data->username));
 
         if (null != $nameTaken) {
             $jsonResponse->addAlert('error', 'Username already in use.');
@@ -263,7 +263,7 @@ $app->post('/users/remove', function() use($app, $jsonResponse) {
         if ($user->id == $data->userId && $actor->isAdmin) {
             $before = $user->export();
             R::trash($user);
-            R::exec('DELETE from board_user WHERE user_id = ?', [$data->userId]);
+            R::exec('DELETE from board_user WHERE user_id = ?', array($data->userId));
 
             logAction($actor->username . ' removed user ' . $before['username'], $before, null);
             $jsonResponse->addAlert('success', 'Removed user ' . $user->username . '.');


### PR DESCRIPTION
**Updated compatibility of arrays with PHP 5.x.**

* Added `array()` instead of just `[]`.
* Created a new variable for `function_call()[]` type of array calling.
* The both forms are not supported in PHP 5.x.

---

I am using WAMPServer with PHP 5.x, which doesn't recognize the below forms:

* `[]`
* `function_call()[]`

So I have updated the code to be compatible with **PHP 5.5-**.

Please accept my pull request. I have verified the correctness and it works well. Thanks. Please let me know if you have any questions. Also, guys, you are awesome! Love your product. :+1: :smile: 

**Update:** Sorry, by mistake I created a PR to the master branch. Please forgive for the same.

Cheers,
Praveen Kumar