### PR TITLE
update Dockerfile to match installation guide

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:trusty
 MAINTAINER Alex van den Hoogen <alex.van.den.hoogen@geodan.nl>
 
 RUN apt-get update && \
-    apt-get install -yq --no-install-recommends git wget nginx php5-fpm php5-sqlite sqlite3 ca-certificates pwgen && \
+    apt-get install -yq --no-install-recommends git wget nginx php5-fpm php5-sqlite sqlite3 ca-certificates pwgen php5-cli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -15,8 +15,11 @@ RUN echo "cgi.fix_pathinfo = 0;" >> /etc/php5/fpm/php.ini && \
 RUN git clone https://github.com/kiswa/TaskBoard.git /var/www && \
     chmod 777 $(find /var/www -type d)
 
+RUN cd /var/www/ && ./build/composer.phar install
+
 ADD nginx.conf /etc/nginx/sites-available/default
 
 EXPOSE 80
 
 CMD service php5-fpm start && nginx
+


### PR DESCRIPTION
The current Dockerfile doesn't work : "Failed to load resource: the server responded with a status of 500 (Internal Server Error)" in browser console when I login with "admin/admin".