### PR TITLE
Fix the scrollback problem, closes #400.

### DIFF
--- a/partials/board.html
+++ b/partials/board.html
@@ -38,7 +38,7 @@
                     <p>Try using the board list above, or checking your <a href="#/settings">Settings</a>.</p>
                 </span>
             </div>
-            <div class="boardColumn" data-ng-repeat="lane in currentBoard.ownLane | orderBy:'position':false"
+            <div class="boardColumn" data-ng-repeat="lane in currentBoard.ownLane | orderBy:'position':false track by lane.id"
                  data-ng-class="{'collapsed': lane.collapsed}" data-lane-id="{{ lane.id }}"
                  data-context-menu="onContextMenu(lane.id)" data-target="laneMenu">
                 <h3>{{ lane.name }}


### PR DESCRIPTION
This small change fixes the automatic scrollback of the long lists. Tested on Chrome and Firefox 57, and it's working well.