### PR TITLE
Fix minify step in build (trailing comma)

### DIFF
--- a/js/controllers/settingsBoardForm.js
+++ b/js/controllers/settingsBoardForm.js
@@ -238,7 +238,7 @@ function ($scope, BoardService) {
             showSelectionPalette: true,
             showButtons: false,
             showInput: true,
-            preferredFormat: 'hex3',
+            preferredFormat: 'hex3'
         });
     };
     $scope.addBoard = function(boardFormData) {
@@ -299,9 +299,9 @@ function ($scope, BoardService) {
         }
     };
     $scope.storeColor = function(e) {
-        if (e.which === 13) { // Enter key 
+        if (e.which === 13) { // Enter key
             $scope.boardFormData.categories.forEach(function(cat){
-                if ((cat.id == $scope.editedCategory.id) && 
+                if ((cat.id == $scope.editedCategory.id) &&
                    (cat.name == $scope.editedCategory.name))
                     cat.color = $scope.boardFormData.color;
             });
@@ -312,7 +312,7 @@ function ($scope, BoardService) {
             $scope.spectrum();
 	    $scope.editedCategory = {};
         }
-    }; 
+    };
 
 
     var checkFormInputs = function(boardFormData) {


### PR DESCRIPTION
This commit fixes an issue while building the whole app.

controllers/settingsBoardForm.js:241: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.            preferredFormat: 'hex3',
                                   