### PR TITLE
Fail to build with latest JS engine

### DIFF
--- a/js/controllers/settingsBoardForm.js
+++ b/js/controllers/settingsBoardForm.js
@@ -238,7 +238,7 @@ function ($scope, BoardService) {
             showSelectionPalette: true,
             showButtons: false,
             showInput: true,
-            preferredFormat: 'hex3',
+            preferredFormat: 'hex3'
         });
     };
     $scope.addBoard = function(boardFormData) {


### PR DESCRIPTION
It seems the misplaced ',' at line 241 is causing a failure to build with openjdk-8-jre