### PR TITLE
Replace apache_request_headers() function call

### DIFF
--- a/api/mailFactory.php
+++ b/api/mailFactory.php
@@ -2,13 +2,11 @@
 require_once('mailConfig.php');
 
 function getServerHost() {
-    $headers = apache_request_headers();
-
-    foreach($headers as $header => $value) {
-        if (strtolower($header) == 'host') {
-            return $value;
-        }
+    $hostname = '';
+    if (false !== ($headers = getallheaders())) {
+        $hostname = (isset($headers['Host']) ? $headers['Host'] : $hostname);
     }
+    return $hostname;
 }
 
 function createMailObject() {


### PR DESCRIPTION
Replaced **apache_request_headers()** function call with **getallheaders()**, which already has a fallback if the server is not running apache.

Since **getallheaders()** is an alias for **apache_request_headers()** no new code should need to be added, since **api/helpers.php** already contains a fallback for this function.

Solves issue #317.