### PR TITLE
Changed the NGINX getallheaders function to work

### DIFF
--- a/api/helpers.php
+++ b/api/helpers.php
@@ -3,12 +3,12 @@ use RedBeanPHP\R;
 // Patch for when using nginx instead of apache, source: http://php.net/manual/en/function.getallheaders.php#84262
 if (!function_exists('getallheaders')) {
     function getallheaders() {
-        $headers = '';
+        $headers = array();
 
         foreach ($_SERVER as $name => $value) {
             if (substr($name, 0, 5) == 'HTTP_') {
                 $headers[str_replace(' ', '-', ucwords(strtolower(
-                    str_replace('_', ' ', substr($name, 5))
+                    ltrim($name, 'HTTP_')
                 )))] = $value;
             }
         }


### PR DESCRIPTION
It did not work because of the lack of array And resulted in an error.
Also the ltrim function is better to read.

I can confirm that the latest version works on NGINX, PHP7 and Amazon Linux 2 on EC2 with this change.