### PR TITLE
Fix base where Taskboard is hosted at root.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,7 @@
       ['/boards', '/settings', '/dashboard'].forEach(p => {
         const i = path.indexOf(p)
 
-        if (i > 0) {
+        if (i >= 0) {
           path = path.substring(0, i);
         }
       });


### PR DESCRIPTION
Fix case where taskboard is hosted at the root url

String.indexOf(x) returns 0 when x is at the beginning of the source string, and -1 if it is not found. So the check needs to include 0 (empty string) as a possible base.

This change is tested on my local environment, applied to 1.0.1