### PR TITLE
Make base rewriting script account for /files urls

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -26,7 +26,7 @@
     (function () {
       var path = window.location.pathname;
 
-      ['/boards', '/settings', '/dashboard'].forEach(p => {
+      ['/boards', '/settings', '/dashboard', '/files'].forEach(p => {
         const i = path.indexOf(p)
 
         if (i >= 0) {


### PR DESCRIPTION
Make the file preview screen work. Previously it was setting the base element equal to the full url in the file preview screen, breaking the script loading.