### PR TITLE
Set a height on the parent and move the toggle.

### DIFF
--- a/src/scss/_core.scss
+++ b/src/scss/_core.scss
@@ -195,6 +195,8 @@ button {
 
 .toggle {
   vertical-align: sub;
+  display: inline-block;
+  height: 20px;
 
   &::before {
     height: 16px;
@@ -202,7 +204,8 @@ button {
   }
 
   &::after {
-    top: -2px;
+    top: 3px;
+    height: 100%;
   }
 }
 


### PR DESCRIPTION
Hey mate,

I tried to just move the toggle, but it wasn't very cross browser friendly.

By doing the following I was able to get it working on macbook chrome/firefox/safari.

I can't test any other browsers though.

This is in relation to #513 