### PR TITLE
Add Docker dev support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.cache
+.github
+.vscode
+node_modules
+Dockerfile
+docker-compose.yml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Chrome",
+      "request": "launch",
+      "type": "pwa-chrome",
+      "url": "http://localhost:8081",
+      "webRoot": "${workspaceFolder}/src"
+    },
+    {
+      "name": "Listen for XDebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9000,
+      "log": true,
+      "externalConsole": false,
+      "pathMappings": {
+          "/var/www/html/api": "${workspaceRoot}/src/api",
+      },
+      "ignore": [
+          "**/vendor/**/*.php"
+      ]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Launch Chrome",
-      "request": "launch",
-      "type": "pwa-chrome",
-      "url": "http://localhost:8081",
-      "webRoot": "${workspaceFolder}/src"
-    },
-    {
       "name": "Listen for XDebug",
       "type": "php",
       "request": "launch",

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN npm install
 
 COPY . ./
 RUN npm run build:prod
-# RUN npm run build:dev
+# RUN npm run build
 
 
 # ------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# -------------------
+# Build Stage 1 (npm)
+# -------------------
+FROM node:alpine AS appbuild
+
+RUN apk add --update --no-cache p7zip
+
+WORKDIR /usr/src/app
+
+COPY ./package.json ./
+RUN npm install
+
+COPY . ./
+RUN npm run build:prod
+# RUN npm run build:dev
+
+
+# ------------------------
+# Build Stage 2 (composer)
+# ------------------------
+FROM composer AS apibuild
+
+WORKDIR /app
+
+COPY ./src/api ./
+RUN composer install
+
+
+# --------------------------
+# Build Stage 3 (php-apache)
+# This build takes the production build from staging builds
+# --------------------------
+FROM php:7.3-apache
+
+ENV PROJECT /var/www/html
+
+RUN apt-get update && apt-get install -y sqlite3 php7.3-sqlite
+RUN a2enmod rewrite expires
+# RUN docker-php-ext-install pdo_mysql
+
+# RUN pecl install xdebug && docker-php-ext-enable xdebug
+# COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+
+WORKDIR $PROJECT
+COPY --from=appbuild /usr/src/app/dist ./
+RUN rm -rf ./api/*
+COPY --from=apibuild /app ./api/
+RUN chmod 777 ./api
+EXPOSE 80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  taskboard:
+    image: "taskboard"
+    build:
+      context: .
+    ports:
+      - "8081:80"

--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
     "ts-node": "^8.10.2",
     "tslib": "^1.13.0",
     "tslint": "^6.1.2",
-    "typescript": "^3.8.3"
+    "typescript": "~3.8.3"
   }
 }

--- a/xdebug.ini
+++ b/xdebug.ini
@@ -1,0 +1,11 @@
+[xdebug]
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20180731/xdebug.so
+xdebug.default_enable=1
+xdebug.remote_enable=1
+xdebug.remote_port=9000
+xdebug.remote_handler=dbgp
+xdebug.remote_connect_back=0
+xdebug.remote_host=host.docker.internal
+xdebug.idekey=VSCODE
+xdebug.remote_autostart=1
+xdebug.remote_log=/usr/local/etc/php/xdebug.log


### PR DESCRIPTION
# Add ability to use vscode and docker as a development environment.

* Also includes a versioning fix for the angular -> typescript dependency (use `~` instead of `^` for typescript, since they [don't follow semantic versioning](https://github.com/microsoft/TypeScript/issues/14116)

Run `docker-compose build` to build the docker image with the tag.
Run `docker-compose up` to run the docker container.

To debug the php, uncomment the lines in the Dockerfile:
```
# RUN pecl install xdebug && docker-php-ext-enable xdebug
# COPY xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
```
Set up the xdebug config in xdebug.ini. Current configuration is for VSCode on the host machine, as configured by launch.json.