### PR TITLE
Fixed due date in email notification

### DIFF
--- a/src/api/controllers/Comments.php
+++ b/src/api/controllers/Comments.php
@@ -212,7 +212,7 @@ class Comments extends BaseController {
 
     $data->taskName = $task->title ?: '';
     $data->taskDescription = $task->description ?: '';
-    $data->taskDueDate = date('F j, Y, g:i:s A', (int)$task->due_date * 1000);
+    $data->taskDueDate = date('F j, Y, g:i:s A', strtotime($task->due_date));
 
     $data->taskAssignees = '';
     foreach($task->sharedUserList as $assignee) {

--- a/src/api/controllers/Comments.php
+++ b/src/api/controllers/Comments.php
@@ -212,7 +212,7 @@ class Comments extends BaseController {
 
     $data->taskName = $task->title ?: '';
     $data->taskDescription = $task->description ?: '';
-    $data->taskDueDate = date('F j, Y, g:i:s A', strtotime($task->due_date));
+    $data->taskDueDate = date('F j, Y', strtotime($task->due_date));
 
     $data->taskAssignees = '';
     foreach($task->sharedUserList as $assignee) {

--- a/src/api/controllers/Tasks.php
+++ b/src/api/controllers/Tasks.php
@@ -386,7 +386,7 @@ class Tasks extends BaseController {
 
     $data->taskName = $task->title ?: '';
     $data->taskDescription = $task->description ?: '';
-    $data->taskDueDate = date('F j, Y, g:i:s A', strtotime($task->due_date));
+    $data->taskDueDate = date('F j, Y', strtotime($task->due_date));
 
     $data->taskAssignees = '';
     foreach($task->sharedUserList as $assignee) {

--- a/src/api/controllers/Tasks.php
+++ b/src/api/controllers/Tasks.php
@@ -386,7 +386,7 @@ class Tasks extends BaseController {
 
     $data->taskName = $task->title ?: '';
     $data->taskDescription = $task->description ?: '';
-    $data->taskDueDate = date('F j, Y, g:i:s A', (int)$task->due_date * 1000);
+    $data->taskDueDate = date('F j, Y, g:i:s A', strtotime($task->due_date));
 
     $data->taskAssignees = '';
     foreach($task->sharedUserList as $assignee) {


### PR DESCRIPTION
Should fix #536 
Problem seemed to be, that the due date is stored as string in the database and no conversion was made

Also removes the time from due date in email, as only a date can be selected in Taskboard