### PR TITLE
Set Charset for PHPMailer to UTF-8

### DIFF
--- a/src/api/helpers/Mailer.php
+++ b/src/api/helpers/Mailer.php
@@ -130,6 +130,7 @@ class Mailer {
     $this->mail->isSendmail();
 
     $this->mail->setFrom(Mailer::FROM_EMAIL, Mailer::FROM_NAME);
+    $this->mail->CharSet = PHPMailer::CHARSET_UTF8;
 
     // @codeCoverageIgnoreStart
     if (!Mailer::USE_SENDMAIL) {


### PR DESCRIPTION
Found out, that Emails were sent with wrong charset in PHPMailer.
So I changed it to UTF-8, just like the texts are stored in the database.

Closes #509 