### PR TITLE
Fix Postgres Support

### DIFF
--- a/src/api/controllers/BaseController.php
+++ b/src/api/controllers/BaseController.php
@@ -81,8 +81,8 @@ abstract class BaseController {
   protected function getAdminEmailAddresses($boardId) {
     $emails = R::getAll('SELECT email FROM user u ' .
       'JOIN board_user bu ON u.id = bu.user_id ' .
-      'WHERE u.security_level < 3 AND u.email <> "" AND board_id = ?',
-      [$boardId]);
+      'WHERE u.security_level < 3 AND u.email <> ? AND board_id = ?',
+      ['', $boardId]);
 
     return count($emails) > 0 ? $emails[0] : [];
   }


### PR DESCRIPTION
double-quotes are not used for string in Postgres -- they're used for escaping identifier names.

This commit fixes a common problem encountered with Postgres which results in frequent logging out of the user.

(a personal release with this change (and others) is available at https://bics.ga/reivilibre/TaskBoard/releases/tag/v1.0.3-rei and https://github.com/reivilibre/TaskBoard/releases/tag/v1.0.3-rei for interested admins -- just noting this because I realise this repo is not in active development)