### PR TITLE
Fix warning that occurs about `sharedTask` not being set

### DIFF
--- a/src/api/controllers/Dashboard.php
+++ b/src/api/controllers/Dashboard.php
@@ -71,7 +71,7 @@ class Dashboard extends BaseController {
       foreach($board["ownCategory"] as $category) {
         $retVal[$index]->categories[] = (object)array(
           "name" => $category["name"],
-          "tasks" => count($category["sharedTask"])
+          "tasks" => count($category["sharedTask"] ?? [])
         );
       }
     }
@@ -137,7 +137,6 @@ class Dashboard extends BaseController {
         }
       }
     }
-
     return R::exportAll($boards);
   }
 


### PR DESCRIPTION
This is only a warning-level issue (at least with my PHP configuration), but I felt compelled to share this back anyway.


(a personal release with this change (and others) is available at https://bics.ga/reivilibre/TaskBoard/releases/tag/v1.0.3-rei and https://github.com/reivilibre/TaskBoard/releases/tag/v1.0.3-rei for interested admins -- just noting this because I realise this repo is not in active development)