### PR TITLE
Add a proper config system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ Thumbs.db
 *.db
 *.sqlite
 *.zip
-
+/src/config.php

--- a/angular.json
+++ b/angular.json
@@ -25,6 +25,11 @@
                 "output": "/api"
               },
               {
+                "glob": "config*.php",
+                "input": "src",
+                "output": "/"
+              },
+              {
                 "glob": "*.json",
                 "input": "src/json",
                 "output": "/strings"

--- a/src/api/index.php
+++ b/src/api/index.php
@@ -11,7 +11,13 @@ use RedBeanPHP\R;
 
 require './vendor/autoload.php';
 
-R::setup('sqlite:taskboard.sqlite');
+$CONFIG = require('../config.default.php');
+if (file_exists('../config.php')) {
+  $CONFIG = array_merge($CONFIG, require('../config.php'));
+}
+
+
+R::setup($CONFIG['database'], $CONFIG['database_user'], $CONFIG['database_password']);
 
 $container = new DI\Container();
 AppFactory::setContainer($container);

--- a/src/config.default.php
+++ b/src/config.default.php
@@ -1,0 +1,23 @@
+<?php
+// Do not edit config.default.php as this may hinder your upgrade to a future version.
+// Make a copy of it called config.php!
+
+return array(
+/**
+ * Database configuration settings.
+ *
+ * SQLite does not use or need a user or password.
+ *
+ * For SQLite, use sqlite:path_to_db.sqlite (the path is relative to the api/ directory).
+ *
+ * For Postgres, use e.g. pgsql:host=localhost;dbname=taskboard for a TCP connection,
+ *              or e.g. pgsql:dbname=taskboard for a UNIX socket connection
+ *
+ * See https://redbeanphp.com/index.php?p=/connection for more options.
+ */
+'database' => 'sqlite:taskboard.sqlite',
+'database_user' => '',
+'database_password' => '',
+
+
+);


### PR DESCRIPTION
This is a bit of an opinionated change, but I thought I should offer it anyway.

This feature lets you copy `config.default.php` to `config.php`, make changes, and then set a custom database (e.g. personally in use: Postgres).

It felt too dirty to have to maintain changes to `api/index.php` :).


(a personal release with this change (and others) is available at https://bics.ga/reivilibre/TaskBoard/releases/tag/v1.0.3-rei and https://github.com/reivilibre/TaskBoard/releases/tag/v1.0.3-rei for interested admins -- just noting this because I realise this repo is not in active development)